### PR TITLE
fix: Deploy step needs the Makefile

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -121,6 +121,15 @@ jobs:
     env:
       ENVIRONMENT: prod
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: false
+          sparse_checkout: |
+            Makefile
+          sparse_checkout_cone_mode: false
+
       - name: Install SAM CLI
         uses: aws-actions/setup-sam@v2
         with:


### PR DESCRIPTION
### Changes

- Utilize a sparse checkout for deploy job to only grab the Makefile from the repo
