### PR TITLE
fix: Deploy stage also needs original SAM template and config

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -128,6 +128,8 @@ jobs:
           submodules: false
           sparse-checkout: |
             Makefile
+            template.yml
+            samconfig.toml
           sparse-checkout-cone-mode: false
 
       - name: Install SAM CLI


### PR DESCRIPTION
Apparently `sam package` also needs the original, unrendered template,
as well as the samconfig.toml
