### PR TITLE
fix: Bad target left in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@ lint: lint-code lint-infra
 .PHONY: build
 build: build-code build-infra
 
-.PHONY: deploy
-deploy: deploy-code deploy-infra
-
 .PHONY: lint-code
 lint-code:
 	@echo "No Java linter configured yet"


### PR DESCRIPTION
The deploy-code and deploy-infra targets were condensed to just deploy
